### PR TITLE
add OpenSSF Scorecard badge and Docker release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,29 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: castingcode/mocka
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ coverage.html
 samples/
 # Added by goreleaser init:
 dist/
+
+# ignore locally plan files
+.plans/
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o mockasrv ./cmd/mockasrv
+
+FROM scratch
+COPY --from=builder /app/mockasrv /mockasrv
+EXPOSE 9000
+ENTRYPOINT ["/mockasrv"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/castingcode/mocka/actions/workflows/test.yml/badge.svg)](https://github.com/castingcode/mocka/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/castingcode/mocka/graph/badge.svg?token=C7EUFCEHED)](https://codecov.io/gh/castingcode/mocka)
 [![Go Report Card](https://goreportcard.com/badge/github.com/castingcode/mocka)](https://goreportcard.com/report/github.com/castingcode/mocka)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/castingcode/mocka/badge)](https://scorecard.dev/viewer/?uri=github.com/castingcode/mocka)
 
 Mocka is an HTTP server that accepts MOCA protocol requests and returns canned responses. It is designed for testing code that talks to a BlueYonder WMS MOCA server without needing a real server present.
 
@@ -178,10 +179,16 @@ Result XML files should contain a `<moca-results>` fragment. See [Result file fo
 
 ### Installation
 
-Download a pre-built binary from the [releases page](https://github.com/castingcode/mocka/releases), or build from source:
+Download a pre-built binary from the [releases page](https://github.com/castingcode/mocka/releases), build from source:
 
 ```sh
 go install github.com/castingcode/mocka/cmd/mockasrv@latest
+```
+
+or run via Docker:
+
+```sh
+docker run -p 9000:9000 -v ./responses:/responses castingcode/mocka
 ```
 
 ### Flags


### PR DESCRIPTION
- Add OpenSSF Scorecard badge to README (workflow already existed)
- Add Dockerfile for mockasrv using a multi-stage scratch image
- Add docker job to release workflow; pushes versioned tag on every release and moves the latest tag on non-pre-releases
- Document Docker as a third installation option in README